### PR TITLE
Fix critically important markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 sbutils
 =======
-###sbutils is a collection of utilities to access iOS functions via ssh and to replace some broken ericautilities.
+### sbutils is a collection of utilities to access iOS functions via ssh and to replace some broken ericautilities.
 At this time, several hotfixes are included. For example, sburlschemes doesn't work at all and sbdevice can't get the UUID.
 
 Installation


### PR DESCRIPTION
There was a missing space, this is an absolute travesty so I corrected it.